### PR TITLE
repair link to keen-js

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -107,7 +107,7 @@
             <div class="help-block" style="width: 300px; margin: 0 auto;">
                 <p style="text-align: center">
                   These charts were created with the Keen IO
-                  <a target="_blank" href="https://keen.io/docs/clients/javascript/usage-guide/">JavaScript SDK</a>.
+                  <a target="_blank" href="https://github.com/keen/keen-js">JavaScript SDK</a>.
                   <br><br>
                   You can also run queries directly from the keen-gem.
                   A route that returns this query is at <a target="_blank" href="/results.json">/results.json</a>.


### PR DESCRIPTION
# What does this PR do?

This PR repairs the Keen-JS link on the Keen Gem Example App page
# Where should the reviewer start?

Check that the link now goes to "https://github.com/keen/keen-js" instead of "https://keen.io/docs/clients/javascript/usage-guide/" (because of Keen doc changes)
# What should be manually tested?

Check that the link now goes to "https://github.com/keen/keen-js" instead of "https://keen.io/docs/clients/javascript/usage-guide/" (because of Keen doc changes)
# Any background context?

Just repairing links!
# Screenshots

![screen shot on 2015-06-18 at 13-13-25](https://cloud.githubusercontent.com/assets/2067501/8241085/03ed8ed6-15bc-11e5-8353-e5e6c578b818.png)
# Random Gif

![harry_potter_pincers](https://cloud.githubusercontent.com/assets/2067501/8241116/3e8b53a2-15bc-11e5-9922-18a6a87301de.gif)
